### PR TITLE
fix: fetch update metadata from the raw changelog CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.2.0
 
 - Added a daily plugin update check. Loading the skill compares the installed
-  plugin version with the latest GitHub release — cached for 24 hours, at most
+  plugin version with the published changelog — cached for 24 hours, at most
   one request per day, silent when offline — and, when outdated, asks the user
   whether to update, showing what the new version added.
 - Added the `tabbit_plugin_update` tool. It records a version the user declined

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A plugin for DeepSeek Harness (DSH) that gives the agent control over your Tabbi
 | --------- | ----------- |
 | `tabbit-browser` skill | The working guide for browser automation: persistent task spaces, locators and waits, screenshots, receipts and recovery. Discovered and loaded automatically with the plugin — no separate skill install. The model loads it via `skill({ name: "tabbit-browser" })` or `/tabbit-browser`. |
 | `tabbit_browser_install` tool | Environment preflight: detects installed stable Tabbit editions, requires version `1.9.0` or newer, and verifies the `tabbit-cli` resident runtime. When Tabbit is missing or outdated, it starts a DSH background job that downloads the region-appropriate installer. |
-| `tabbit_plugin_update` tool | Plugin update check: compares the installed plugin version with the latest GitHub release at most once a day, silently skips offline failures, and records a version the user declined. When a newer release exists, the skill loads with an update notice showing what the new version added. |
+| `tabbit_plugin_update` tool | Plugin update check: compares the installed plugin version with the published changelog at most once a day, silently skips offline failures, and records a version the user declined. When a newer release exists, the skill loads with an update notice showing what the new version added. |
 
 ## Installation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 | ---- | ---- |
 | `tabbit-browser` skill | 浏览器自动化工作指南：持久化任务空间、locator 与等待、截图、回执与恢复。随插件安装自动发现和加载，无需单独安装。模型通过 `skill({ name: "tabbit-browser" })` 或 `/tabbit-browser` 加载。 |
 | `tabbit_browser_install` 工具 | 环境预检：检测已安装的正式版 Tabbit、要求版本 ≥ `1.9.0`、检查 `tabbit-cli` 常驻运行时；未安装或版本过低时，创建 DSH 后台任务按地区下载对应安装包。 |
-| `tabbit_plugin_update` 工具 | 插件更新检查：每天至多一次对比本地插件版本与 GitHub 最新 Release，离线失败时静默跳过，并可记录用户已拒绝的版本。存在新版本时，skill 会附带更新提示加载，展示新版本的新增功能。 |
+| `tabbit_plugin_update` 工具 | 插件更新检查：每天至多一次对比本地插件版本与仓库发布的 CHANGELOG，离线失败时静默跳过，并可记录用户已拒绝的版本。存在新版本时，skill 会附带更新提示加载，展示新版本的新增功能。 |
 
 ## 安装
 

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ export function registerUpdateTool(ctx, {
 } = {}) {
   ctx.tools.register({
     name: 'tabbit_plugin_update',
-    description: 'Record that the user declined an offered tabbit-browser plugin version, or force a recheck of the latest plugin release. The skill already loads an update notice automatically when a newer version exists; call this tool only after the user declines an offered version, or after a plugin update or connectivity change.',
+    description: 'Record that the user declined an offered tabbit-browser plugin version, or force a recheck of the published changelog. The skill already loads an update notice automatically when a newer version exists; call this tool only after the user declines an offered version, or after a plugin update or connectivity change.',
     parameters: {
       type: 'object',
       properties: {

--- a/tests/update-check.test.mjs
+++ b/tests/update-check.test.mjs
@@ -7,7 +7,7 @@ import {
   checkPluginUpdate,
   compareVersions,
   dismissUpdate,
-  parseLatestRelease,
+  parseLatestChangelog,
   readCachedCheck,
   summarizeUpdate,
   truncateChangelog,
@@ -49,12 +49,28 @@ test('flattens and truncates release notes', () => {
   assert.ok(long.endsWith('…'))
 })
 
-test('parses the latest GitHub release payload', () => {
+test('parses the newest version section from the changelog', () => {
+  const markdown = [
+    '# Changelog',
+    '',
+    '## 0.3.0',
+    '',
+    '- Added update',
+    '  checks.',
+    '',
+    '## 0.2.0',
+    '',
+    '- Older release.',
+  ].join('\n')
   assert.deepEqual(
-    parseLatestRelease({ tag_name: 'v0.3.0', body: 'Added update\nchecks.' }),
-    { version: '0.3.0', changelog: 'Added update checks.' },
+    parseLatestChangelog(markdown),
+    { version: '0.3.0', changelog: '- Added update checks.' },
   )
-  assert.throws(() => parseLatestRelease({ body: 'no tag' }), /tag_name/)
+  assert.deepEqual(
+    parseLatestChangelog('## v0.3.0\n\nOnly section.\n'),
+    { version: '0.3.0', changelog: 'Only section.' },
+  )
+  assert.throws(() => parseLatestChangelog('# No version headings'), /heading/)
 })
 
 test('summarizes the update state', () => {

--- a/update-check.js
+++ b/update-check.js
@@ -5,7 +5,9 @@ import { dirname, join } from 'node:path'
 const DAY_MS = 24 * 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 1500
 const CHANGELOG_MAX_CHARS = 500
-const DEFAULT_RELEASE_URL = 'https://api.github.com/repos/Tabbit-Browser/dsh-plugin/releases/latest'
+// The raw CDN carries no GitHub API rate limit, which unauthenticated checks
+// from shared egress IPs would otherwise exhaust within the hour.
+const DEFAULT_CHANGELOG_URL = 'https://raw.githubusercontent.com/Tabbit-Browser/dsh-plugin/main/CHANGELOG.md'
 const PACKAGE_URL = new URL('./package.json', import.meta.url)
 
 let cachedLocalVersion
@@ -38,10 +40,17 @@ export function truncateChangelog(text) {
   return `${value.slice(0, CHANGELOG_MAX_CHARS - 1).trimEnd()}…`
 }
 
-export function parseLatestRelease(payload) {
-  const version = numericVersion(payload?.tag_name)?.join('.')
-  if (!version) throw new Error('Latest release payload has no usable tag_name.')
-  return { version, changelog: truncateChangelog(payload.body) }
+export function parseLatestChangelog(markdown) {
+  const match = String(markdown ?? '').match(/^## +(v?\d+(?:\.\d+)+).*$/m)
+  if (!match) throw new Error('Latest changelog has no version heading.')
+  const version = numericVersion(match[1])?.join('.')
+  if (!version) throw new Error('Latest changelog heading has no usable version.')
+  const sectionStart = match.index + match[0].length
+  const nextSection = String(markdown).slice(sectionStart).search(/^## +/m)
+  const section = nextSection === -1
+    ? String(markdown).slice(sectionStart)
+    : String(markdown).slice(sectionStart, sectionStart + nextSection)
+  return { version, changelog: truncateChangelog(section) }
 }
 
 export function defaultCacheFile(env = process.env, platform = process.platform) {
@@ -78,20 +87,17 @@ async function writeCachedCheck(cacheFile, state) {
   await writeFile(cacheFile, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
 }
 
-export async function fetchLatestRelease({
-  url = process.env.TABBIT_PLUGIN_UPDATE_URL || DEFAULT_RELEASE_URL,
+export async function fetchLatestChangelog({
+  url = process.env.TABBIT_PLUGIN_UPDATE_URL || DEFAULT_CHANGELOG_URL,
   timeoutMs = FETCH_TIMEOUT_MS,
   fetchImpl = fetch,
 } = {}) {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const response = await fetchImpl(url, {
-      signal: controller.signal,
-      headers: { accept: 'application/vnd.github+json' },
-    })
+    const response = await fetchImpl(url, { signal: controller.signal })
     if (!response.ok) throw new Error(`Update check failed with HTTP ${response.status}.`)
-    return parseLatestRelease(await response.json())
+    return parseLatestChangelog(await response.text())
   } finally {
     clearTimeout(timer)
   }
@@ -144,7 +150,7 @@ async function fetchAndCacheRelease({ currentVersion, cached, cacheFile, now, fe
 export async function checkPluginUpdate({
   now = Date.now(),
   cacheFile = defaultCacheFile(),
-  fetchRelease = fetchLatestRelease,
+  fetchRelease = fetchLatestChangelog,
   readVersion = readLocalVersion,
   force = false,
 } = {}) {


### PR DESCRIPTION
## Summary
- Replace the unauthenticated GitHub releases API (60 req/h per IP — instantly exhausted on shared egress IPs, so the check failed forever for those users) with `raw.githubusercontent.com` serving `CHANGELOG.md`: no API rate limit, one request yields both the newest version and its notes.
- `parseLatestChangelog` parses the newest `## x.y.z` section; wording across README (en/zh), tool description, and CHANGELOG now matches the actual data source.
- Tests: 32 passing; live end-to-end verified: a 0.1.0 install now reports `update-available` with the 0.2.0 changelog.