### PR TITLE
chore: point all remaining references at the dsh-tabbit repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Run `dsh --version` again to confirm DSH works.
 ### 2. Install the tabbit-browser plugin
 
 ```sh
-dsh plugin --profile web add github:Tabbit-Browser/dsh-plugin
+dsh plugin --profile web add github:Tabbit-Browser/dsh-tabbit
 ```
 
 ### 3. Start DSH

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,7 @@ npm install -g @deepseek-ai/dsh
 ### 2. 安装 tabbit-browser 插件
 
 ```sh
-dsh plugin --profile web add github:Tabbit-Browser/dsh-plugin
+dsh plugin --profile web add github:Tabbit-Browser/dsh-tabbit
 ```
 
 ### 3. 启动 DSH

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ export function formatUpdateNotice({ currentVersion, latestVersion, changelog })
     '> Show the offered version and these changes to the user, then ask whether to update now.',
     '> If they agree, tell them to rerun the install command below over the current install and restart the DSH session afterwards:',
     '> ```bash',
-    '> dsh plugin --profile web add github:Tabbit-Browser/dsh-plugin',
+    '> dsh plugin --profile web add github:Tabbit-Browser/dsh-tabbit',
     '> ```',
     `> If they decline, call \`tabbit_plugin_update\` with \`dismiss: "${latestVersion}"\`, then continue the task.`,
   ]

--- a/skills/tabbit-browser/SKILL.md
+++ b/skills/tabbit-browser/SKILL.md
@@ -74,7 +74,7 @@ update now. If they agree, tell them to rerun the install command below over
 the current install, then restart the DSH session afterwards:
 
 ```bash
-dsh plugin --profile web add github:Tabbit-Browser/dsh-plugin
+dsh plugin --profile web add github:Tabbit-Browser/dsh-tabbit
 ```
 
 If they decline, call `tabbit_plugin_update` with `dismiss` set to the offered

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -157,7 +157,7 @@ test('prepends the plugin-update notice when a newer release exists', async () =
     /^> \*\*Plugin update available\*\*: tabbit-browser 0\.3\.0 \(installed 0\.2\.0\)/,
   )
   assert.match(skill.content, /New in 0\.3\.0: Added update checks\./)
-  assert.match(skill.content, /dsh plugin --profile web add github:Tabbit-Browser\/dsh-plugin/)
+  assert.match(skill.content, /dsh plugin --profile web add github:Tabbit-Browser\/dsh-tabbit/)
   assert.match(skill.content, /tabbit_plugin_update.*dismiss: "0\.3\.0"/)
   assert.match(skill.content, /# Tabbit Browser/)
 })

--- a/update-check.js
+++ b/update-check.js
@@ -7,7 +7,7 @@ const FETCH_TIMEOUT_MS = 1500
 const CHANGELOG_MAX_CHARS = 500
 // The raw CDN carries no GitHub API rate limit, which unauthenticated checks
 // from shared egress IPs would otherwise exhaust within the hour.
-const DEFAULT_CHANGELOG_URL = 'https://raw.githubusercontent.com/Tabbit-Browser/dsh-plugin/main/CHANGELOG.md'
+const DEFAULT_CHANGELOG_URL = 'https://raw.githubusercontent.com/Tabbit-Browser/dsh-tabbit/main/CHANGELOG.md'
 const PACKAGE_URL = new URL('./package.json', import.meta.url)
 
 let cachedLocalVersion


### PR DESCRIPTION
## Summary

Completes the rename started in 2053933 (package + repository renamed to `dsh-tabbit`): seven call sites still referenced the old `Tabbit-Browser/dsh-plugin` location.

## Changes

- **`update-check.js`** — `DEFAULT_CHANGELOG_URL` now reads the renamed repo's raw CDN. This is the critical one: GitHub's raw CDN redirects for renamed repos are not guaranteed, and once they lapse the daily update check would fail silently.
- **`index.js`** — install command in the plugin-update notice shown to users.
- **`skills/tabbit-browser/SKILL.md`**, **`README.md`**, **`README.zh-CN.md`**, **`docs/02-…内容企划与初稿.md`** — install command updated to `github:Tabbit-Browser/dsh-tabbit`.
- **`tests/plugin.test.mjs`** — update-notice assertion aligned with the new install command.
- Removed the stale `tabbit-browser-0.2.1.tgz` artifact built under the old package name.

## Verification

- `npm test`: 32/32 pass
- `npm pack --dry-run`: `dsh-tabbit@0.2.0`, 14 files
- Repo-wide grep for `Tabbit-Browser/dsh-plugin`: zero matches