### PR TITLE
fix: update cordis patch entry name to dsh-tabbit after package rename

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,3 +1,3 @@
 - insert:
     - id: skill-tabbit-browser
-      name: tabbit-browser
+      name: dsh-tabbit


### PR DESCRIPTION
The package was renamed to dsh-tabbit in 0.2.1, but cordis.patch.yml still references the old name tabbit-browser. Since the entry name is used to resolve the module at boot, dsh fails to start after upgrading to 0.2.1/0.2.2.

This PR updates the entry name to match the new package name.

Verified locally: upgrading to dsh-tabbit@0.2.2 with this fix boots the web profile successfully.