### PR TITLE
feat: surface the detected cliPath and tolerate CRLF skill files

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,10 +74,15 @@ export function createSkillProvider({ checkUpdate = checkPluginUpdate } = {}) {
   }
 }
 
-function stripFrontmatter(source) {
-  if (!source.startsWith('---\n')) return source
-  const end = source.indexOf('\n---\n', 4)
-  return end === -1 ? source : source.slice(end + 5)
+export function stripFrontmatter(source) {
+  // Windows checkouts may carry CRLF line endings; tolerate both so the
+  // frontmatter is stripped regardless of the working-tree line ending style.
+  const newline = source.startsWith('---\r\n') ? '\r\n' : '\n'
+  const opening = `---${newline}`
+  if (!source.startsWith(opening)) return source
+  const closing = `${newline}---${newline}`
+  const end = source.indexOf(closing, opening.length)
+  return end === -1 ? source : source.slice(end + closing.length)
 }
 
 export const name = 'tabbit-browser'
@@ -220,6 +225,7 @@ export function registerInstallerTool(ctx, {
             enum: ['default', 'danger-full-access'],
           },
           cliSandboxReason: { type: 'string' },
+          cliPath: { type: 'string' },
           minimumVersion: { type: 'string' },
           playwrightProcessRunning: { type: 'boolean' },
           playwrightInstanceCount: { type: 'integer' },
@@ -289,9 +295,10 @@ export function registerInstallerTool(ctx, {
           : ''
         const result = {
           status: 'ready',
-          ...withCliSandboxGuidance(`Browser installation and Runtime-process detection passed${versions ? ` (${versions})` : ''}.${instanceNote} Run the normal tabbit-cli tasks connection probe to finish the environment check.`, detected.platform),
+          ...withCliSandboxGuidance(`Browser installation and Runtime-process detection passed${versions ? ` (${versions})` : ''}.${detected.cliPath ? ` CLI: ${detected.cliPath}.` : ''}${instanceNote} Run the normal tabbit-cli tasks connection probe to finish the environment check.`, detected.platform),
           cached: false,
           cliReady: detected.cliReady,
+          cliPath: detected.cliPath,
           minimumVersion: detected.minimumVersion,
           playwrightProcessRunning: detected.playwrightProcessRunning,
           playwrightInstanceCount: detected.playwrightInstanceCount,
@@ -310,6 +317,7 @@ export function registerInstallerTool(ctx, {
           ...withCliSandboxGuidance(`Environment check failed: ${versions} meets the minimum version ${detected.minimumVersion}, but the tabbit-cli Runtime is not running. Please restart Tabbit Browser once before using browser automation.`, detected.platform),
           cached: false,
           cliReady: detected.cliReady,
+          cliPath: detected.cliPath,
           minimumVersion: detected.minimumVersion,
           playwrightProcessRunning: false,
           playwrightInstanceCount: detected.playwrightInstanceCount,
@@ -341,6 +349,7 @@ export function registerInstallerTool(ctx, {
         cached: false,
         jobId: String(jobId),
         cliReady: detected.cliReady,
+        cliPath: detected.cliPath,
         minimumVersion: detected.minimumVersion,
         playwrightProcessRunning: false,
         playwrightInstanceCount: detected.playwrightInstanceCount,

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -9,6 +9,7 @@ import {
   name,
   registerInstallerTool,
   registerUpdateTool,
+  stripFrontmatter,
 } from '../index.js'
 
 const UP_TO_DATE = async () => ({ status: 'current', currentVersion: '0.2.0' })
@@ -69,6 +70,7 @@ test('registers one bundled tabbit-browser skill and both tools', async () => {
   )
   assert.equal(tool.parameters.properties.refresh.type, 'boolean')
   assert.match(tool.description, /session-scoped CLI connection probe/)
+  assert.equal(tool.output.schema.properties.cliPath.type, 'string')
 
   const provider = factory({})
   const candidates = await provider.list()
@@ -135,6 +137,52 @@ test('caches successful Browser and Runtime-process detection for the whole agen
   assert.equal(second.cached, true)
   assert.match(second.message, /Runtime-process detection reused this session's result/)
   assert.equal(refreshed.cached, false)
+})
+
+test('strips skill frontmatter with LF or CRLF line endings', () => {
+  const lf = '---\nname: demo\ndescription: d\n---\n\n# Demo\nbody'
+  assert.equal(stripFrontmatter(lf), '\n# Demo\nbody')
+  const crlf = '---\r\nname: demo\r\ndescription: d\r\n---\r\n\r\n# Demo\r\nbody'
+  assert.equal(stripFrontmatter(crlf), '\r\n# Demo\r\nbody')
+  assert.equal(stripFrontmatter('no frontmatter'), 'no frontmatter')
+  assert.equal(stripFrontmatter('---\nnever closed'), '---\nnever closed')
+})
+
+test('reports the detected cliPath in the installer tool result', async () => {
+  let tool
+  registerInstallerTool({
+    tools: {
+      register(value) {
+        tool = value
+        return () => {}
+      },
+    },
+    jobs: {},
+  }, {
+    hostPlatform: 'win32',
+    async detect() {
+      return {
+        platform: 'win32',
+        recommendation: 'ready',
+        minimumVersion: '1.9.0',
+        cliReady: true,
+        cliPath: String.raw`C:\Users\User\AppData\Local\Tabbit\LocalAgent\bin\tabbit-cli.exe`,
+        playwrightProcessRunning: true,
+        playwrightInstanceCount: 1,
+        playwrightRuntimeAmbiguous: false,
+        installations: [],
+        supportedInstallations: [],
+      }
+    },
+  })
+
+  const agent = {}
+  const result = await tool.execute({}, { agent })
+  const cached = await tool.execute({}, { agent })
+
+  assert.equal(result.cliPath, String.raw`C:\Users\User\AppData\Local\Tabbit\LocalAgent\bin\tabbit-cli.exe`)
+  assert.match(result.message, /CLI: C:\\Users\\User\\AppData\\Local\\Tabbit\\LocalAgent\\bin\\tabbit-cli\.exe/)
+  assert.equal(cached.cliPath, result.cliPath)
 })
 
 test('does not load an unrelated candidate', async () => {


### PR DESCRIPTION
## Summary

Two small improvements on top of the existing detection flow:

1. **Expose the resolved launcher path (`cliPath`)** — `detectTabbit` already resolves the stable tabbit-cli launcher (`%LOCALAPPDATA%\Tabbit\LocalAgent\bin\tabbit-cli.exe` on Windows, `~/.local/bin/tabbit-cli` elsewhere), but `tabbit_browser_install` never returned it. This PR adds `cliPath` to the tool's output schema and to every result branch (ready / restart-required / background, including session-cached copies), and mentions it in the ready message. Agents can now invoke the launcher directly instead of guessing from platform docs.

2. **Tolerate CRLF skill files in `stripFrontmatter`** — the frontmatter stripper assumed LF-only line endings. On Windows checkouts (git autocrlf) the `---` frontmatter was never stripped, so the skill content served to models included the raw YAML header. The helper now detects LF vs CRLF and is exported for direct testing.

## Test plan

- `node --test`: 34/34 pass (3 new tests: CRLF/LF frontmatter stripping, `cliPath` in tool result + cached copy, schema property).
- Verified on a real Windows machine: `detectTabbit()` returns `ready` with `cliPath` pointing at the stable LocalAgent entry and the Runtime process detected.
