### PR TITLE
fix(client): inject uiConversation so the web client activates on current DSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.1
+
+- Fixed the web client plugin never activating on current DSH hosts — the web
+  UI showed `dsh-tabbit: pending (waiting for service: conversationEvents)`.
+  The DSH client runtime refactor (already part of `0.1.2-alpha.1`) renamed the
+  `conversationEvents` service to `uiConversation` and moved node registration
+  from `service.register()` to `service.events.register()`. The client plugin
+  now injects `uiConversation`; the `/tabbit-info` status card, the `@tab`
+  composer source, and the watching-instance hint all had been blocked behind
+  that pending inject and work again. The `conversation.chat.node` keyed slot
+  registration and the Definition contract (`match`/`start`/`update`/
+  `buildViewNode`) are unchanged.
+
 ## 0.3.0
 
 - Major upgrade: browser automation now runs through the native

--- a/client/client.js
+++ b/client/client.js
@@ -35,8 +35,9 @@ var module = { exports: {} }; var exports = module.exports;
  * dsh 客户端插件协议与服务端 Cordis 如出一辙：导出 {name, inject, apply(ctx)}；
  * 这里注入的 'inputTriggers' 是 dsh-client-ui-input-trigger 提供的"输入框
  * 触发菜单"服务（package.json dsh.client.inject 里声明了要它一起装）；
- * 'conversationEvents'/'slots' 是 dsh-client-runtime（web 包核心）恒定
- * 提供的服务，不用额外声明。
+ * 'uiConversation'/'slots' 是 web 客户端核心恒定提供的服务，不用额外声明
+ * （'uiConversation' 是宿主 0.1.2-alpha.1 客户端重构后 'conversationEvents'
+ * 的新名字，注册入口相应从 service.register() 移到了 service.events.register()）。
  * 共享的触发菜单负责渲染候选列表 UI——@tab 部分只提供数据，不需要 React。
  *
  * 功能三：把服务端 /tabbit-info 命令落下的 tabbit/status 会话事件折成
@@ -310,8 +311,8 @@ function TabbitStatusNodeView({ node }) {
 }
 
 /*
- * tabbit/status 事件 → 聊天节点的 Definition（conversationEvents 服务的
- * 契约形状，同 dsh 文档 adding-a-conversation-node 的单事件业务写法）。
+ * tabbit/status 事件 → 聊天节点的 Definition（uiConversation 服务的契约
+ * 形状，同 dsh 文档 adding-a-conversation-node 的单事件业务写法）。
  * 每次执行落一条整值事件，以 event.seq 为节点身份各自独立成行——重复
  * 执行 /tabbit-info 天然多行并存、不互相覆盖；anchorSeq 用事件自身的
  * seq，位置正好落在命令行节点（command/run）之后。start/update 都是纯
@@ -345,7 +346,7 @@ const tabbitStatusNode = {
 
 module.exports = {
   name: 'dsh-tabbit-client',
-  inject: ['inputTriggers', 'conversationEvents', 'slots'],
+  inject: ['inputTriggers', 'uiConversation', 'slots'],
   apply(ctx) {
     // 观看实例打点：告诉服务端"是哪个浏览器在看这个页面"。fire-and-forget
     // （不 await、双层吞错）——纯属锦上添花的提示，任何失败都不能影响页面。
@@ -370,14 +371,14 @@ module.exports = {
       }
     }
 
-    // 功能三：/tabbit-info 状态卡。conversationEvents/slots 已在 inject 里
+    // 功能三：/tabbit-info 状态卡。uiConversation/slots 已在 inject 里
     // 声明（apply 只会在它们就绪后运行），这里仍按本文件惯例做形状防御。
     // 两者内部都是 ctx.effect 式注册（随插件 fiber 卸载自动回收），直接调。
-    const conversationEvents = ctx.get('conversationEvents');
+    const uiConversation = ctx.get('uiConversation');
     const slots = ctx.get('slots');
-    if (conversationEvents && typeof conversationEvents.register === 'function'
+    if (uiConversation && typeof uiConversation.events?.register === 'function'
         && slots && typeof slots.inject === 'function') {
-      conversationEvents.register(tabbitStatusNode);
+      uiConversation.events.register(tabbitStatusNode);
       slots.inject('conversation.chat.node', () => slots.register(
         { name: 'conversation.chat.node', key: 'tabbit-status' },
         TabbitStatusNodeView,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tabbit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Tabbit Browser bundle for DeepSeek Harness: a code-first tabbit_browser tool, browser-backed web_fetch, @tab composer mentions, a dedicated page-access permission, an environment preflight with background installer download, and a daily plugin update check.",
   "repository": {
     "type": "git",

--- a/tests/client.test.mjs
+++ b/tests/client.test.mjs
@@ -23,8 +23,8 @@ function mockServices({ registeredNodes, slotRegistrations, sources }) {
       if (name === 'inputTriggers') {
         return { registerSource: (source) => { sources.push(source); return () => {} } }
       }
-      if (name === 'conversationEvents') {
-        return { register: (definition) => { registeredNodes.push(definition); return () => {} } }
+      if (name === 'uiConversation') {
+        return { events: { register: (definition) => { registeredNodes.push(definition); return () => {} } } }
       }
       if (name === 'slots') {
         return {
@@ -42,7 +42,7 @@ test('registers the @tab source and the tabbit-status chat node', () => {
   const fakeReact = { createElement: (type, props, ...children) => ({ type, props, children }), useState: () => [false, () => {}] }
   const client = loadClient(fakeReact)
   assert.equal(client.name, 'dsh-tabbit-client')
-  assert.deepEqual(client.inject, ['inputTriggers', 'conversationEvents', 'slots'])
+  assert.deepEqual(client.inject, ['inputTriggers', 'uiConversation', 'slots'])
 
   const registeredNodes = []
   const slotRegistrations = []


### PR DESCRIPTION
## Problem

On current DSH hosts the web UI reports:

> Failed to load plugins — web boot: 1 entry did not activate — dsh-tabbit: pending (waiting for service: conversationEvents)

The whole client entry (`client/client.js`) never activates, which silently
takes down all three client-side features at once: the `@tab` composer source,
the watching-instance hint (`POST /tabbit/instance-hint`), and the
`/tabbit-info` status card. Server-side entries are unaffected.

## Root cause

The DSH client runtime refactor (already part of `0.1.2-alpha.1`) renamed the
`conversationEvents` service to `uiConversation` and moved node registration
from `service.register()` to `service.events.register()` (see
`packages/client/ui-conversation/src/client/conversation/assembly.ts` and
`event-registry.ts` in the harness). The client plugin kept injecting the old
name, and cordis only runs `apply()` once every injected service resolves — so
the entry stayed pending forever. No published dsh-tabbit version matches
current hosts (0.2.x targets the pre-refactor runtime), so there is no
downgrade path; the plugin needs this rename.

## Change

- `inject: ['inputTriggers', 'uiConversation', 'slots']`
- fetch the service as `ctx.get('uiConversation')` and register the
  status-card Definition through `uiConversation.events.register(tabbitStatusNode)`,
  with the shape guard updated to `uiConversation.events?.register`
- comments updated to the new names

The Definition contract (`match`/`start`/`update`/`buildViewNode`) and the
`conversation.chat.node` keyed slot registration are unchanged on the host, so
`tabbitStatusNode` itself needs no edits. First-party precedent for the new
idiom: `packages/client/ui-goal/src/client/index.ts`.

## Tests

- `tests/client.test.mjs`: mock and inject assertion updated; suite passes (2/2).
- Verified against a live host end to end: built, packed, installed into a DSH
  web profile from the tarball, restarted `dsh web` — boot is clean and the
  served client module carries the new inject list.
- Unrelated pre-existing note: on machines with a real Tabbit Browser
  installed, a few tests that assume an instance-registry-free environment
  already fail at the v0.3.0 tag (unchanged by this PR).
