### PR TITLE
chore: release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.3
+
+- Restored web-client compatibility with DSH `0.1.1-rc.2`. The client no
+  longer hard-injects either generation of the conversation service: it uses
+  `uiConversation.events` on DSH `0.1.2-alpha.1+` and falls back to
+  `conversationEvents` on `0.1.1`, so neither host remains pending while
+  waiting for the other generation's service name.
+
 ## 0.3.2
 
 - `tabbit_browser` gains `list_tasks: true`: a zero-side-effect readback of

--- a/client/client.js
+++ b/client/client.js
@@ -35,9 +35,11 @@ var module = { exports: {} }; var exports = module.exports;
  * dsh 客户端插件协议与服务端 Cordis 如出一辙：导出 {name, inject, apply(ctx)}；
  * 这里注入的 'inputTriggers' 是 dsh-client-ui-input-trigger 提供的"输入框
  * 触发菜单"服务（package.json dsh.client.inject 里声明了要它一起装）；
- * 'uiConversation'/'slots' 是 web 客户端核心恒定提供的服务，不用额外声明
- * （'uiConversation' 是宿主 0.1.2-alpha.1 客户端重构后 'conversationEvents'
- * 的新名字，注册入口相应从 service.register() 移到了 service.events.register()）。
+ * 'slots' 是 web 客户端核心恒定提供的服务；会话节点注册服务在宿主
+ * 0.1.2-alpha.1 从 'conversationEvents' 政名为 'uiConversation'，注册入口
+ * 也从 service.register() 移到了 service.events.register()。两者不能作为
+ * 硬注入，否则另一代宿主会让整个客户端插件永久 pending，故在 apply
+ * 中按新接口优先、旧接口兜底的顺序探测。
  * 共享的触发菜单负责渲染候选列表 UI——@tab 部分只提供数据，不需要 React。
  *
  * 功能三：把服务端 /tabbit-info 命令落下的 tabbit/status 会话事件折成
@@ -346,7 +348,7 @@ const tabbitStatusNode = {
 
 module.exports = {
   name: 'dsh-tabbit-client',
-  inject: ['inputTriggers', 'uiConversation', 'slots'],
+  inject: ['inputTriggers', 'slots'],
   apply(ctx) {
     // 观看实例打点：告诉服务端"是哪个浏览器在看这个页面"。fire-and-forget
     // （不 await、双层吞错）——纯属锦上添花的提示，任何失败都不能影响页面。
@@ -371,14 +373,19 @@ module.exports = {
       }
     }
 
-    // 功能三：/tabbit-info 状态卡。uiConversation/slots 已在 inject 里
-    // 声明（apply 只会在它们就绪后运行），这里仍按本文件惯例做形状防御。
-    // 两者内部都是 ctx.effect 式注册（随插件 fiber 卸载自动回收），直接调。
+    // 功能三：/tabbit-info 状态卡。新宿主使用 uiConversation.events，
+    // 0.1.1 宿主使用 conversationEvents；只要任一接口存在就注册状态卡。
+    // 服务内部都是 ctx.effect 式注册（随插件 fiber 卸载自动回收），直接调。
     const uiConversation = ctx.get('uiConversation');
+    const conversationEvents = ctx.get('conversationEvents');
     const slots = ctx.get('slots');
-    if (uiConversation && typeof uiConversation.events?.register === 'function'
-        && slots && typeof slots.inject === 'function') {
-      uiConversation.events.register(tabbitStatusNode);
+    const registerStatusNode = typeof uiConversation?.events?.register === 'function'
+      ? (definition) => uiConversation.events.register(definition)
+      : typeof conversationEvents?.register === 'function'
+        ? (definition) => conversationEvents.register(definition)
+        : undefined;
+    if (registerStatusNode && slots && typeof slots.inject === 'function') {
+      registerStatusNode(tabbitStatusNode);
       slots.inject('conversation.chat.node', () => slots.register(
         { name: 'conversation.chat.node', key: 'tabbit-status' },
         TabbitStatusNodeView,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-tabbit",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Tabbit Browser bundle for DeepSeek Harness: a code-first tabbit_browser tool, browser-backed web_fetch, @tab composer mentions, a dedicated page-access permission, an environment preflight with background installer download, and a daily plugin update check.",
   "repository": {
     "type": "git",

--- a/tests/client.test.mjs
+++ b/tests/client.test.mjs
@@ -16,15 +16,18 @@ function loadClient(fakeReact) {
   })
 }
 
-/* 三个宿主服务的最小假件：记录注册物，形状对齐各自服务契约。 */
-function mockServices({ registeredNodes, slotRegistrations, sources }) {
+/* 宿主服务的最小假件：可切换新旧会话 API，记录真实的注册结果。 */
+function mockServices({ registeredNodes, slotRegistrations, sources, conversationApi = 'new' }) {
   return {
     get(name) {
       if (name === 'inputTriggers') {
         return { registerSource: (source) => { sources.push(source); return () => {} } }
       }
-      if (name === 'uiConversation') {
+      if (name === 'uiConversation' && conversationApi === 'new') {
         return { events: { register: (definition) => { registeredNodes.push(definition); return () => {} } } }
+      }
+      if (name === 'conversationEvents' && conversationApi === 'old') {
+        return { register: (definition) => { registeredNodes.push(definition); return () => {} } }
       }
       if (name === 'slots') {
         return {
@@ -32,7 +35,7 @@ function mockServices({ registeredNodes, slotRegistrations, sources }) {
           register: (spec, view) => ({ spec, view }),
         }
       }
-      throw new Error(`unexpected service: ${name}`)
+      return undefined
     },
     effect(fn) { const cleanup = fn(); return () => cleanup?.() },
   }
@@ -42,7 +45,7 @@ test('registers the @tab source and the tabbit-status chat node', () => {
   const fakeReact = { createElement: (type, props, ...children) => ({ type, props, children }), useState: () => [false, () => {}] }
   const client = loadClient(fakeReact)
   assert.equal(client.name, 'dsh-tabbit-client')
-  assert.deepEqual(client.inject, ['inputTriggers', 'uiConversation', 'slots'])
+  assert.deepEqual(client.inject, ['inputTriggers', 'slots'])
 
   const registeredNodes = []
   const slotRegistrations = []
@@ -77,6 +80,39 @@ test('registers the @tab source and the tabbit-status chat node', () => {
   assert.equal(slotRegistrations[0].slot, 'conversation.chat.node')
   const seat = slotRegistrations[0].callback()
   assert.equal(seat.spec.key, 'tabbit-status')
+})
+
+test('registers the status node through the DSH 0.1.1 conversationEvents service', () => {
+  const fakeReact = { createElement: (type, props, ...children) => ({ type, props, children }), useState: () => [false, () => {}] }
+  const client = loadClient(fakeReact)
+  const registeredNodes = []
+  const slotRegistrations = []
+  const sources = []
+
+  client.apply(mockServices({
+    registeredNodes, slotRegistrations, sources, conversationApi: 'old',
+  }))
+
+  assert.equal(sources.length, 1)
+  assert.equal(registeredNodes.length, 1)
+  assert.equal(registeredNodes[0].kind, 'tabbit-status')
+  assert.equal(slotRegistrations.length, 1)
+})
+
+test('keeps @tab active when no conversation status-card service exists', () => {
+  const fakeReact = { createElement: (type, props, ...children) => ({ type, props, children }), useState: () => [false, () => {}] }
+  const client = loadClient(fakeReact)
+  const registeredNodes = []
+  const slotRegistrations = []
+  const sources = []
+
+  client.apply(mockServices({
+    registeredNodes, slotRegistrations, sources, conversationApi: 'none',
+  }))
+
+  assert.equal(sources.length, 1)
+  assert.equal(registeredNodes.length, 0)
+  assert.equal(slotRegistrations.length, 0)
 })
 
 test('renders the status card with a language-following details toggle', () => {


### PR DESCRIPTION
## Summary

- restore web-client compatibility with DSH 0.1.1-rc.2 via `conversationEvents.register()`
- retain DSH 0.1.2-alpha.1+ support via `uiConversation.events.register()`
- remove the generation-specific hard inject that left the other host pending
- keep `@tab` active when no status-card conversation service is available
- bump the package and changelog to 0.3.3

## Validation

- user acceptance passed on old and new DSH hosts
- `npm test` — 82/82 passed
- `npm pack --dry-run` — passed and includes release files
- independent code review — no Critical or Important findings